### PR TITLE
Rewrite for more API usage over normal commands

### DIFF
--- a/autoload/stagehand.vim
+++ b/autoload/stagehand.vim
@@ -104,7 +104,7 @@ func! stagehand#close_curtains()
   let l:ft = &filetype
 
   " Create the buffer
-  exec 'new backstage'
+  exec 'new Backstage'
   setl nobuflisted noswapfile buftype=acwrite bufhidden=wipe
 
   call setline(1, l:output)

--- a/autoload/stagehand.vim
+++ b/autoload/stagehand.vim
@@ -14,12 +14,10 @@ func! stagehand#store_selection()
   let l:pos = getpos('.')
 
   " Check for V-LINE mode
-  exec "normal! \<esc>gv"
-  if mode() ==# 'V'
-    " Remove the ending newline
-    exec "normal! \<esc>`<v`>$h"
+  if visualmode() ==# 'V'
+    " Convert V-LINE to VISUAL
+    exec "normal! `<v`>$\<esc>"
   endif
-  exec "normal! \<esc>"
 
   exec "normal! `<"
   let l:start = getpos('.')

--- a/autoload/stagehand.vim
+++ b/autoload/stagehand.vim
@@ -111,6 +111,11 @@ func! stagehand#close_curtains()
 
   " TODO: Remove undo history from new buffer
   " exec "set ul=-1 | m-1 | let &ul=" . &ul
+  let old_ul = &ul
+  set ul=-1
+  exe "normal a \<bs>\<esc>"
+  let &ul = old_ul
+  unlet old_ul
 
   let b:original = l:bufnr
   let b:selection = l:selection

--- a/autoload/stagehand.vim
+++ b/autoload/stagehand.vim
@@ -107,15 +107,8 @@ func! stagehand#close_curtains()
   exec 'new Backstage'
   setl nobuflisted noswapfile buftype=acwrite bufhidden=wipe
 
-  call setline(1, l:output)
-
-  " TODO: Remove undo history from new buffer
-  " exec "set ul=-1 | m-1 | let &ul=" . &ul
-  let old_ul = &ul
-  set ul=-1
-  exe "normal a \<bs>\<esc>"
-  let &ul = old_ul
-  unlet old_ul
+  " Remove undo history while adding text to the new buffer
+  exec "set ul=-1 | call setline(1, l:output) | let &ul=" . &ul
 
   let b:original = l:bufnr
   let b:selection = l:selection

--- a/autoload/stagehand.vim
+++ b/autoload/stagehand.vim
@@ -1,6 +1,6 @@
 " stagehand.vim - stage code behind a curtain
 " Author:  Miles Manners <https://repo.dmm.gg>
-" Version: 1.1
+" Version: 2.0
 
 if exists("g:loaded_stagehand") | finish | endif
 let g:loaded_stagehand = 1
@@ -8,130 +8,62 @@ let g:loaded_stagehand = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-" Saves the current gv, excluding the newline at the end of V-LINE
-func! stagehand#store_selection()
-  " Store the cursor position so we can restore it later
-  let l:pos = getpos('.')
-
-  " Check for V-LINE mode
-  if visualmode() ==# 'V'
-    " Convert V-LINE to VISUAL
-    exec "normal! `<v`>$\<esc>"
-  endif
-
-  exec "normal! `<"
-  let l:start = getpos('.')
-
-  exec "keeppatterns normal! v`>l"
-  call search('[^\n]', 'b')
-  let l:end = getpos('.')
-
-  exec "normal! \<esc>"
-
-  " Restore the cursor position like nothing ever happened
-  call setpos('.', l:pos)
-
-  return [l:start, l:end]
-endfunc
-
-func! stagehand#restore_selection(selection)
-  let result = setpos('.', a:selection[0])
-  if result == -1
-    return -1
-  endif
-  exec "normal! v"
-  return setpos('.', a:selection[1])
-endfunc
-
-" Protects a register to prevent pollution inside a function
-func! stagehand#wrap_register(reg, fn)
-  " Store the register as a list of lines
-  let [l:contents, l:type] = [getreg(a:reg), getregtype(a:reg)]
-  try
-    return a:fn()
-  finally
-    " Restore the register to its original value
-    call setreg(a:reg, l:contents, l:type)
-  endtry
-endfunc
-
-func! stagehand#get_selection()
-  exec "normal! gvy"
-  return split(getreg('"'), '\n')
-endfunc
-
 " Bring those changes out from backstage
 func! stagehand#open_curtains()
   if ! &modified
     return 0
   endif
 
-  let l:bufnr = bufnr('%')
-  let l:pos = getpos('.')
-  let l:selection = b:selection
+  let l:pos = getcurpos()
 
   " Copy everything from backstage
-  exec "normal! gg0vG$"
-  call search('[^\n]', 'b')
-  exec "normal! y"
+  exe "normal! G$"
+  let l:text = getline('^', search('[^\n]', 'b'))
 
-  " Don't wipe everything in case of no exit
-  setl bufhidden=hide
-  exec ':b ' . b:original
-
-  " TODO: Figure out why deleting everything fails to paste
-
-  " Replace the old section (and update our gv)
-  call stagehand#restore_selection(l:selection)
-  exec "normal! \"_dPv`]\<esc>"
+  " Deleting/appdending accounts for differing amounts of lines
+  call deletebufline(b:original, b:lines[0], b:lines[1])
+  call appendbufline(b:original, b:lines[0] - 1, l:text)
 
   " Renew our saved selection in case of no exit
-  let l:selection = stagehand#store_selection()
+  let b:lines[1] = b:lines[0] + len(l:text) - 1
 
   call setpos('.', l:pos)
-  setl bufhidden=wipe
-  let b:selection = l:selection
 endfunc
 
 func! s:clear_autocmd()
   au! * <buffer>
 
-  if exists('#User#StagehandLeave')
-    do User StagehandLeave
-  endif
+  if exists('#User#StagehandLeave') | do User StagehandLeave | endif
 endfunc
 
 " Close the curtains and get ready to make the magic happen
 func! stagehand#close_curtains()
-  " Save the selected region so we don't lose our place
-  let l:selection = stagehand#store_selection()
+  let l:pos = getcurpos()
 
-  let l:output = stagehand#wrap_register('"', funcref('stagehand#get_selection'))
+  exe "normal! `>"
+  let l:lines = [line("'<"), search('[^\n]', 'b', line("'<"))]
+
+  call setpos('.', l:pos)
+
+  let l:output = getline(l:lines[0], l:lines[1])
 
   let l:bufnr = bufnr('%')
   let l:ft = &filetype
 
-  " Create the buffer
-  exec 'new Backstage' . l:bufnr . l:selection[0][1] . '-' . l:selection[1][1]
-  setl nobuflisted noswapfile buftype=acwrite bufhidden=wipe
+  exe 'new Backstage@' . l:bufnr . ':' . l:lines[0][1] . '-' . l:lines[1][1]
+  exe "set nobl noswf bt=acwrite bh=wipe nomod ft=" . l:ft
 
   " Remove undo history while adding text to the new buffer
-  exec "set ul=-1 | call setline(1, l:output) | let &ul=" . &ul
+  exe "set ul=-1 | call setline(1, l:output) | let &ul=" . &ul
 
   let b:original = l:bufnr
-  let b:selection = l:selection
+  let b:lines = l:lines
 
   " Replace saving with opening the curtains
-  au BufWriteCmd <buffer> call stagehand#wrap_register('"', funcref('stagehand#open_curtains')) | set nomodified
+  au BufWriteCmd <buffer> call stagehand#open_curtains() | set nomodified
   au BufWinLeave <buffer> call <SID>clear_autocmd()
 
-  " Allow opening the curtains with no error messages
-  set nomodified
-  exec "set filetype=" . ft
-
-  if exists('#User#StagehandEnter')
-    do User StagehandEnter
-  endif
+  if exists('#User#StagehandEnter') | do User StagehandEnter | endif
 endfunc
 
 let &cpo = s:cpo_save

--- a/doc/stagehand.txt
+++ b/doc/stagehand.txt
@@ -30,4 +30,6 @@ The only way to keep undo history from backstage is to save constantly.
 
 The initial filling of backstage can be undone.
 
+Inline backstages cause very strange behavior on replacement.
+
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/stagehand.txt
+++ b/doc/stagehand.txt
@@ -28,8 +28,6 @@ Deleting everything backstage and trying to save it while empty breaks it.
 
 The only way to keep undo history from backstage is to save constantly.
 
-The initial filling of backstage can be undone.
-
-Inline backstages cause very strange behavior on replacement.
+There is no way to exclude part of a line.
 
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Using more API commands allows for many improvements.

The initial intent was to decrease the amount of "*noise*" from some normal commands like yanking.

But it also led to a drastically less complex plugin with much less wrapping and repeated behavior.

This means that there are now only two external functions and a single internal function. The whole thing is now a *measly 70 lines* of `autoload` + 2 lines of mapping.